### PR TITLE
Renew profiles expiring within N days or force renewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Apple Developer Progaram の各種作業をサポートするツール。
 破損したプロビジョニングプロファイルを再生成する。
 
 ```
-repair_profiles [-t TEAM_ID] [profile_name] ...
+repair_profiles [-t TEAM_ID] [-f] [--expires-within-days INT] [profile_name] ...
 ```
 
 以下の状態にあるプロファイルを破損として取り扱う。
@@ -21,8 +21,11 @@ repair_profiles [-t TEAM_ID] [profile_name] ...
 - Invalid になっているもの
 - プロファイルに対して登録できる証明書がすべて有効になっていないもの
 - プロファイルに対して登録できる UDID がすべて有効になっていないもの
+- `--expires-within-days` で指定された日数以内に期限切れをむかえるもの
 
 破損したプロファイルに対しては、登録できる証明書と UDID をすべて登録した状態で再発行する。
+
+`-f`, `--force` フラグを使うと上述の条件とは無関係に再発行する。
 
 `profile_name` を指定すると、その名前のプロファイルのみを対象にできる。
 
@@ -47,6 +50,16 @@ sync_deploygate_devices [-t TEAM_ID] [-u DEPLOYGATE_USER_ID] [-k DEPLOYGATE_API_
 - -u は `DEPLOYGATE_USER` と -k は `DEPLOYGATE_API_KEY` をそれぞれ環境変数で指定することで省略できる。
 - -n に ADP 登録名のプレフィクスを指定することができる。
 
+## devices
+
+```
+devices [-t TEAM_ID] [CSV_FILE_PATH]
+```
+
+登録されているデバイスの情報を CSV ファイルとして出力する。
+
+`CSV_FILE_PATH` が存在しない場合は標準出力に結果を出力する。
+ファイルとして書き出したい場合は `CSV_FILE_PATH` を使ってファイルパスを指定することを強くオススメする。なぜならリダイレクトを使うと Spaceship が吐くメッセージなども標準出力に出てしまうため。
 
 
 ## License

--- a/repair_profiles
+++ b/repair_profiles
@@ -1,10 +1,24 @@
 #!/usr/bin/env ruby
 require_relative 'lib/adp'
 require 'optparse'
+require 'date'
 
-params = ARGV.getopts('ft:', 'force', 'team:')
+# 期限日が指定日数以内かどうかを判定。
+#
+# @param date [Date] チェックしたい期限日
+# @param from [Date] 基準となる日。デフォルトでは実行日時。
+# @param withinDays [Integer] 日数。デフォルトでは60日（約2ヶ月）
+# @return [bool] `date` が `from` から `withinDays` 日以内なら false を返す。
+def expires(date:, from: Date.today, withinDays: 60)
+  diff = date - from
+  diff.to_i < withinDays
+end
+
+
+params = ARGV.getopts('ft:', 'force', 'team:', 'expires-within-days:')
 team = params['team'] || params['t']
 force_repair = params['force'] || params['f']
+expires_within_days = params['expires-within-days'].to_i || 60 # デフォルトでは60日以内に期限切れを迎えるものは更新するようにする。
 profile_filter = ARGV
 
 service = AdpService.new
@@ -63,8 +77,9 @@ profiles.each do |profile|
   else
     certificates = registed_certificate_ids[:dev].sort
   end
-  
-  need_repair = (detail['status'] != 'Active') || (certificates != current_certificates) || (devices != current_devices)
+
+  date_expire = Date.parse(detail['dateExpire'])
+  need_repair = (detail['status'] != 'Active') || expires(date: date_expire, withinDays: expires_within_days) || (certificates != current_certificates) || (devices != current_devices)
   unless force_repair || need_repair
     next
   end

--- a/repair_profiles
+++ b/repair_profiles
@@ -2,8 +2,9 @@
 require_relative 'lib/adp'
 require 'optparse'
 
-params = ARGV.getopts('t:', 'team:')
+params = ARGV.getopts('ft:', 'force', 'team:')
 team = params['team'] || params['t']
+force_repair = params['force'] || params['f']
 profile_filter = ARGV
 
 service = AdpService.new
@@ -64,7 +65,7 @@ profiles.each do |profile|
   end
   
   need_repair = (detail['status'] != 'Active') || (certificates != current_certificates) || (devices != current_devices)
-  if !need_repair
+  unless force_repair || need_repair
     next
   end
 


### PR DESCRIPTION
Provisioning profiles will expire shorter than the certificate expire in most of cases. Previous version of `repair_profiles` won't repair even the profile will expire within few days.

I fixed that. You have to options:

- The default behavior is renew profiles expiring within 60 days. You can change days using 'expires-within-days’ option.
- You can force renew using `-f` or `--force` flag.
